### PR TITLE
Fix auth decoding, pass userId to BTCPay wallet overview, tighten BTC…

### DIFF
--- a/src/app/api/middleware/auth.ts
+++ b/src/app/api/middleware/auth.ts
@@ -20,7 +20,7 @@ export function withAuth(
             id?: string;
             user_id?: string;
           }>(token);
-          userId = decoded.sub || decoded.id || decoded.user_id;
+          userId = decoded.sub || decoded.id || decoded.user_id || null;
         } catch (e) {
           console.error('Auth: Failed to decode Bearer token:', e);
           userId = null;
@@ -43,7 +43,7 @@ export function withAuth(
               id?: string;
               user_id?: string;
             }>(token);
-            userId = decoded.sub || decoded.id || decoded.user_id;
+            userId = decoded.sub || decoded.id || decoded.user_id || null;
             console.log(
               'Auth: Cookie token decoded, userId:',
               userId,

--- a/src/app/api/payments/btcpay/wallets/BTC/overview/route.ts
+++ b/src/app/api/payments/btcpay/wallets/BTC/overview/route.ts
@@ -17,7 +17,7 @@ export const GET = withAuth(async (req: NextRequest, userId: string) => {
       userId
     );
 
-    const overview = await btcpayService.getWalletOverview();
+    const overview = await btcpayService.getWalletOverview(userId);
 
     return NextResponse.json({
       success: true,

--- a/src/app/link/[slug]/page.tsx
+++ b/src/app/link/[slug]/page.tsx
@@ -142,57 +142,23 @@ export default function ZatoLinkPage() {
         user?.id ||
         `guest_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
-      const items = cartItems.map((item) => ({
-        polarProductId: item.polarProductId,
-        priceId: item.priceId,
-        quantity: item.quantity,
-        productData: item.productData,
-      }));
-
-      const metadata = {
-        total_amount: total.toString(),
-        store_slug: slug,
-        store_owner_id: layout.owner_id,
-      };
-
       if (paymentMethod === 'cash') {
         const { checkoutCashOrder } = await import(
           '@/services/cash-payments.service'
         );
 
-        const cashData = {
-          userId: guestId,
-          ownerId: layout.owner_id,
-          items,
-          metadata,
-        };
+        const items = cartItems.map((item) => ({
+          productId: item.id,
+          quantity: item.quantity,
+          price: item.price,
+        }));
 
-        const response = await checkoutCashOrder(cashData);
+        const response = await checkoutCashOrder({ items });
 
-        if (response.success && response.checkout_url) {
-          window.location.href = response.checkout_url;
+        if (response.success && response.order) {
+          window.location.href = '/success';
         } else {
           throw new Error(response.message || 'Failed to create cash order');
-        }
-      } else {
-        const { checkoutPolarCart } = await import(
-          '@/services/payments-service'
-        );
-
-        const cartData = {
-          userId: guestId,
-          ownerId: layout.owner_id,
-          items,
-          successUrl: `${window.location.origin}/success`,
-          metadata,
-        };
-
-        const response = await checkoutPolarCart(cartData);
-
-        if (response.success && response.checkout_url) {
-          window.location.href = response.checkout_url;
-        } else {
-          throw new Error(response.message || 'Failed to create checkout');
         }
       }
     } catch (error) {

--- a/src/modules/backend/payments/btcpay/service.ts
+++ b/src/modules/backend/payments/btcpay/service.ts
@@ -77,7 +77,9 @@ export class BTCPayService {
     if (request.currency !== 'BTC') {
       try {
         const rate = await this.client.getBTCRate(request.currency);
-        const amountInBTC = (parseFloat(request.amount) / rate).toFixed(8);
+        const amountInBTC = (parseFloat(String(request.amount)) / rate).toFixed(
+          8
+        );
         amountToUse = amountInBTC;
         currencyToUse = 'BTC';
       } catch (error) {
@@ -117,7 +119,7 @@ export class BTCPayService {
     }
 
     if (userXpub) {
-      enrichedRequest.metadata.userXpub = userXpub;
+      (enrichedRequest.metadata as any).userXpub = userXpub;
     }
 
     console.log(
@@ -127,7 +129,7 @@ export class BTCPayService {
 
     const invoice = await this.client.createInvoice(
       this.storeId,
-      enrichedRequest
+      enrichedRequest as CreateInvoiceRequest
     );
 
     const btcpayUrl = process.env.BTCPAY_URL || '';


### PR DESCRIPTION
…Pay typings, and simplify cash checkout flow

- Ensure decoded JWT user id falls back to null (avoid undefined) for Bearer and cookie tokens.
- Pass userId into BTCPayService.getWalletOverview call.
- Normalize BTCPay invoice amount handling (coerce amount to string before parseFloat), cast enrichedRequest metadata.userXpub, and cast createInvoice arg to expected type.
- Simplify checkout flow for cash: build items payload inside cash branch, call checkoutCashOrder with { items }, and redirect to /success on success; remove the removed Polar checkout branch.