### PR TITLE
ocr: add OCR cooldown context and integrate into OCR result page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { PluginProvider } from '@/context/plugin-context';
 import { AuthProvider } from '@/components/auth/AuthProvider';
 import { CashSuccessProvider } from '@/context/cash-success-context';
 import { CryptoSuccessProvider } from '@/context/crypto-success-context';
+import { OCRProvider } from '@/context/ocr-context';
 import LayoutWrapper from '@/components/LayoutWrapper';
 import CashSuccessPortal from '@/components/CashSuccessPortal';
 import CryptoSuccessPortal from '@/components/CryptoSuccessPortal';
@@ -43,17 +44,19 @@ export default function RootLayout({
     <html lang="es" className={`${GeistSans.variable}`}>
       <body className="antialiased">
         <PluginProvider>
-          <LanguageProvider>
-            <AuthProvider>
-              <CashSuccessProvider>
-                <CryptoSuccessProvider>
-                  <LayoutWrapper>{children}</LayoutWrapper>
-                  <CashSuccessPortal />
-                  <CryptoSuccessPortal />
-                </CryptoSuccessProvider>
-              </CashSuccessProvider>
-            </AuthProvider>
-          </LanguageProvider>
+          <OCRProvider>
+            <LanguageProvider>
+              <AuthProvider>
+                <CashSuccessProvider>
+                  <CryptoSuccessProvider>
+                    <LayoutWrapper>{children}</LayoutWrapper>
+                    <CashSuccessPortal />
+                    <CryptoSuccessPortal />
+                  </CryptoSuccessProvider>
+                </CashSuccessProvider>
+              </AuthProvider>
+            </LanguageProvider>
+          </OCRProvider>
         </PluginProvider>
       </body>
     </html>

--- a/src/context/ocr-context.tsx
+++ b/src/context/ocr-context.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+interface OCRContextType {
+  cooldownUntil: number | null;
+  setCooldown: (until: number) => void;
+  clearCooldown: () => void;
+  isOnCooldown: boolean;
+  remainingTime: string;
+}
+
+const OCRContext = createContext<OCRContextType | undefined>(undefined);
+
+export const OCRProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [cooldownUntil, setCooldownUntil] = useState<number | null>(null);
+  const [nowTs, setNowTs] = useState<number>(Date.now());
+  const [remainingTime, setRemainingTime] = useState<string>('');
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem('ocr_cooldown_until');
+    if (stored) {
+      const until = parseInt(stored, 10);
+      if (until > Date.now()) {
+        setCooldownUntil(until);
+      } else {
+        sessionStorage.removeItem('ocr_cooldown_until');
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (cooldownUntil) {
+      sessionStorage.setItem('ocr_cooldown_until', cooldownUntil.toString());
+    } else {
+      sessionStorage.removeItem('ocr_cooldown_until');
+    }
+  }, [cooldownUntil]);
+
+  useEffect(() => {
+    if (!cooldownUntil) {
+      setRemainingTime('');
+      return;
+    }
+    const updateTime = () => {
+      const ts = Date.now();
+      setNowTs(ts);
+      const remainingMs = cooldownUntil - ts;
+      if (remainingMs <= 0) {
+        setCooldownUntil(null);
+        setRemainingTime('');
+        sessionStorage.removeItem('ocr_cooldown_until');
+        return;
+      }
+      const totalSec = Math.floor(remainingMs / 1000);
+      const m = String(Math.floor(totalSec / 60)).padStart(2, '0');
+      const s = String(totalSec % 60).padStart(2, '0');
+      setRemainingTime(`${m}:${s}`);
+    };
+    updateTime();
+    const id = setInterval(updateTime, 1000);
+    return () => clearInterval(id);
+  }, [cooldownUntil]);
+
+  const setCooldown = (until: number) => {
+    setCooldownUntil(until);
+  };
+
+  const clearCooldown = () => {
+    setCooldownUntil(null);
+  };
+
+  const isOnCooldown = cooldownUntil ? nowTs < cooldownUntil : false;
+
+  return (
+    <OCRContext.Provider
+      value={{
+        cooldownUntil,
+        setCooldown,
+        clearCooldown,
+        isOnCooldown,
+        remainingTime,
+      }}
+    >
+      {children}
+    </OCRContext.Provider>
+  );
+};
+
+export const useOCR = () => {
+  const context = useContext(OCRContext);
+  if (!context) {
+    throw new Error('useOCR must be used within an OCRProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
- Introduce src/context/ocr-context.tsx providing cooldown state, remainingTime, persistence (sessionStorage), and helpers (setCooldown, clearCooldown, isOnCooldown).
- Wrap OCRProvider in RootLayout so OCR cooldown state is available app-wide.
- Refactor ocr-result page to use useOCR instead of local cooldown/timer state:
  - remove duplicated timer logic
  - disable upload button and show a warning banner while on cooldown
  - set cooldown after successful processing and on 429 / Too Many Requests
  - small cleanup/formatting fixes around item mapping and handlers